### PR TITLE
fix(windows): use windows path separator and cmd-shim

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+environment:
+  matrix:
+    - nodejs_version: '6'
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+    - nodejs_version: '0.12'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm install
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+test_script:
+  - node --version
+  - npm --version
+  - npm run test-win

--- a/index.js
+++ b/index.js
@@ -2,19 +2,34 @@
 var shell = require('shelljs');
 var tempWrite = require('temp-write');
 var shebangRegex = require('shebang-regex');
+var cmdShim = require('cmd-shim');
+var Promise = require('pinkie-promise');
+var pify = require('pify');
 
 module.exports = function (bin, shebang, code) {
 	if (!shebangRegex.test(shebang)) {
 		shebang = '#!/usr/bin/env ' + shebang;
 	}
 
+	// On windows shebangs aren't supported. Use a fake extension to prevent
+	// the bin from being executed instead of the shim.
+	var fileName = bin + (process.platform === 'win32' ? '.x-mock-bin' : '');
+
 	var oldPath = shell.env.PATH;
 
-	var ret = tempWrite(shebang + '\n' + code, bin)
+	var ret = tempWrite(shebang + '\n' + code, fileName)
 		.then(function (filepath) {
+			// Path separator according to platform
+			var sep = process.platform === 'win32' ? ';' : ':';
 			shell.chmod('+x', filepath);
-			shell.env.PATH = filepath.replace(new RegExp(bin + '$'), '') + ':' + oldPath;
+			shell.env.PATH = filepath.replace(new RegExp(fileName + '$'), '') + sep + oldPath;
 
+			if (process.platform === 'win32') {
+				// on windows shebangs aren't supported, add cmd shim
+				return pify(cmdShim, Promise)(filepath, filepath.replace(new RegExp('\\.x-mock-bin$'), ''));
+			}
+		})
+		.then(function () {
 			return function () {
 				if (oldPath) {
 					shell.env.PATH = oldPath;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava",
+    "test-win": "xo && ava --serial"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "executable"
   ],
   "dependencies": {
+    "cmd-shim": "^2.0.2",
+    "pify": "^2.3.0",
+    "pinkie-promise": "^2.0.1",
     "shebang-regex": "^2.0.0",
     "shelljs": "^0.7.0",
     "temp-write": "^2.1.0"


### PR DESCRIPTION
Fix running on windows by:
- using the semicolon path separator when on windows
- using the cmd-shim package for creating bootstrap scripts for the executable  

`cmd-shim` is the same package npm uses to link dependency scripts. 
There is the slight difference that we need to store the executable 
a mock file extension to allow cmd-shim's cygwin bootstrap script to work.

fixes #2
